### PR TITLE
Concurrent api handling milestone 3

### DIFF
--- a/app/src/main/assets/map.html
+++ b/app/src/main/assets/map.html
@@ -8,7 +8,7 @@
 
     <!--    Fetching the Data from Google Maps API-->
     <script async
-            src="https://maps.googleapis.com/maps/api/js?key=AIzaSyBCC4t6nFEZpSw_1xdXFuClxgJVCBRGGmo&callback=initMap">
+            src="https://maps.googleapis.com/maps/api/js?key=&callback=initMap">
     </script>
     <body>
         <div id="map"></div>

--- a/app/src/main/assets/map.html
+++ b/app/src/main/assets/map.html
@@ -8,7 +8,7 @@
 
     <!--    Fetching the Data from Google Maps API-->
     <script async
-            src="https://maps.googleapis.com/maps/api/js?key=&callback=initMap">
+            src="https://maps.googleapis.com/maps/api/js?key=AIzaSyBCC4t6nFEZpSw_1xdXFuClxgJVCBRGGmo&callback=initMap">
     </script>
     <body>
         <div id="map"></div>

--- a/app/src/main/java/com/wordpress/anujsaxenadev/googlemaps/features/map/view/WebViewInterceptor.kt
+++ b/app/src/main/java/com/wordpress/anujsaxenadev/googlemaps/features/map/view/WebViewInterceptor.kt
@@ -23,9 +23,10 @@ class WebViewInterceptor(
         request: WebResourceRequest?
     ): WebResourceResponse? {
         val channel = Channel<WebResourceResponse?>()
-
         // Launch a coroutine to handle the requests
         ioScope.launch {
+//            Can try adding delay in the coroutine. You will see async calls happeing without blocking other requests.
+//            delay((0..3000L).random())
             val result = mapViewModel.checkResourceAvailability(request)
 
             result.fold({

--- a/app/src/main/java/com/wordpress/anujsaxenadev/googlemaps/features/map/view/WebViewInterceptor.kt
+++ b/app/src/main/java/com/wordpress/anujsaxenadev/googlemaps/features/map/view/WebViewInterceptor.kt
@@ -1,25 +1,43 @@
 package com.wordpress.anujsaxenadev.googlemaps.features.map.view
 
+import android.util.Log
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import com.wordpress.anujsaxenadev.googlemaps.features.map.view_model.MapViewModel
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 
 class WebViewInterceptor(
     private val mapViewModel: MapViewModel
 ): WebViewClient() {
+    private val ioScope: CoroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+
     override fun shouldInterceptRequest(
         view: WebView?,
         request: WebResourceRequest?
     ): WebResourceResponse? {
-        return runBlocking {
+        Log.e("anuj-log-called", request?.url.toString())
+        val result = ioScope.async{
+            Log.e("anuj-log-started", request?.url.toString())
+            delay((1..5000L).random())
             mapViewModel.checkResourceAvailability(request).fold({
+                Log.e("anuj-log-was-cached", request?.url.toString())
                 it
             }, {
+                Log.e("anuj-log-was-not-called", request?.url.toString())
                 super.shouldInterceptRequest(view, request)
             })
+        }
+        return runBlocking {
+            Log.e("anuj-log-awaited", request?.url.toString())
+            result.await()
         }
     }
 }

--- a/app/src/main/java/com/wordpress/anujsaxenadev/googlemaps/features/map/view_model/MapViewModel.kt
+++ b/app/src/main/java/com/wordpress/anujsaxenadev/googlemaps/features/map/view_model/MapViewModel.kt
@@ -30,7 +30,7 @@ class MapViewModel @Inject constructor(
     }
 
     companion object{
-        private const val CANCELLATION_TIMEOUT = 5000L
+        private const val CANCELLATION_TIMEOUT = 500L
     }
 
     fun getWebViewClient(): WebViewClient{


### PR DESCRIPTION
**Problem -**
shouldInterceptRequest processes every url sequentially, But the responses are processed concurrently by the webview, Which means shouldIntercept becomes a bottleneck

**Solution -**
- Created IO Scope to ensure that Calls happened on IO Scope without blocking Webview Thread.
- Using Async to Ensure the calls starts executing on different thread without intervention.
- Using Timeout To ensure that user should not experience any significant delay. It will cancel the Coroutine if it executes for too long.
- Using Channels  - This approach will still block the shouldInterceptRequest function, but it will no longer be a bottleneck. Instead, it will simply wait for the first request to complete before returning a response. Other requests will still be processed concurrently in the background.